### PR TITLE
User SAML authentication is not working

### DIFF
--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update -y && apt-get install -y \
   python3.8-distutils \
   rsync \
   curl \
+  xmlsec1 \
+  libxmlsec1-openssl \
   sudo \
   git && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Based on documentation(https://docs.gethue.com/administrator/configuration/server/#saml) we need xmlsec1 and libxmlsec1-openssl libraries  for SAML authentication, if we dont add it, we will get below error
```middleware   INFO     Processing exception: xmlsec binary not found: /usr/bin/xmlsec1: Traceback (most recent call last):
  File "/usr/share/hue/build/env/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/usr/share/hue/desktop/core/ext-py3/djangosaml2-0.18.0/djangosaml2/views.py", line 146, in login
    conf = get_config(config_loader_path, request)
  File "/usr/share/hue/desktop/core/ext-py3/djangosaml2-0.18.0/djangosaml2/conf.py", line 70, in get_config
    return config_loader(request)
  File "/usr/share/hue/desktop/libs/libsaml/src/libsaml/saml_settings.py", line 44, in config_settings_loader
    conf.load({
  File "/usr/share/hue/desktop/core/ext-py3/pysaml2-5.0.0/src/saml2/config.py", line 384, in load
    self.load_complex(cnf, metadata_construction=metadata_construction)
  File "/usr/share/hue/desktop/core/ext-py3/pysaml2-5.0.0/src/saml2/config.py", line 318, in load_complex
    self.load_metadata(cnf["metadata"]))
  File "/usr/share/hue/desktop/core/ext-py3/pysaml2-5.0.0/src/saml2/config.py", line 424, in load_metadata
    mds = MetadataStore(acs, self, ca_certs,
  File "/usr/share/hue/desktop/core/ext-py3/pysaml2-5.0.0/src/saml2/mdstore.py", line 938, in __init__
    self.security = security_context(config)
  File "/usr/share/hue/desktop/core/ext-py3/pysaml2-5.0.0/src/saml2/sigver.py", line 1042, in security_context
    raise SigverError(err_msg)
saml2.sigver.SigverError: xmlsec binary not found: /usr/bin/xmlsec1```


you can see, other people also have faced the same issue > 
https://github.com/cloudera/hue/discussions/2618#discussioncomment-1645258

## What changes were proposed in this pull request?

- add `xmlsec1` and `libxmlsec1-openssl` in `tools/docker/hue/Dockerfile` file to install it

## How was this patch tested?

- manually tested, I have been using hue with proposed changes, before this it was not working
