### PR TITLE
Added nodeselector, toleration and affinity in helm chart

### DIFF
--- a/tools/kubernetes/helm/hue/templates/configmap-hue.yaml
+++ b/tools/kubernetes/helm/hue/templates/configmap-hue.yaml
@@ -21,8 +21,12 @@ data:
     [aws]
     [[aws_accounts]]
     [[[default]]]
+    {{- if eq .Values.aws.allowEnvironmentCredentials "yes" }}
+    allow_environment_credentials={{ .Values.aws.allowEnvironmentCredentials }}
+    {{ else }}
     access_key_id={{ .Values.aws.accessKeyId }}
     secret_access_key={{ .Values.aws.secretAccessKey }}
+    {{- end }}
     region={{ .Values.aws.region }}
 
     [notebook]

--- a/tools/kubernetes/helm/hue/templates/deployment-hue.yaml
+++ b/tools/kubernetes/helm/hue/templates/deployment-hue.yaml
@@ -84,6 +84,18 @@ spec:
           mountPath: /etc/nginx/sites-available/hue
           subPath: hue
 {{ end }}
+{{- with .Values.hue.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- with .Values.hue.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- with .Values.hue.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/tools/kubernetes/helm/hue/values.yaml
+++ b/tools/kubernetes/helm/hue/values.yaml
@@ -4,6 +4,9 @@ image:
    pullPolicy: "Always"
 hue:
   replicas: 2
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
   database:
     create: true
     persist: true
@@ -72,6 +75,7 @@ aws:
   accessKeyId: ""
   secretAccessKey: ""
   region: "us-east-1"
+  allowEnvironmentCredentials: "yes"
 hive:
   site: |
     <!--

--- a/tools/kubernetes/helm/hue/values.yaml
+++ b/tools/kubernetes/helm/hue/values.yaml
@@ -75,7 +75,7 @@ aws:
   accessKeyId: ""
   secretAccessKey: ""
   region: "us-east-1"
-  allowEnvironmentCredentials: "yes"
+  allowEnvironmentCredentials: "no"
 hive:
   site: |
     <!--


### PR DESCRIPTION
## What changes were proposed in this pull request?

- added the nodeSelector, affinity and tolerations to help developers schedule  pods as per their requirements
- Also added possibility to use aws credentials from ec2 metadata instead of providing accesskey, secretkey

## How was this patch tested?

- I tested it using `helm template -f values.yaml . > temp.yaml` command to generate end deployment file from helm. It added new information as per expected and then i deployed in my EKS cluster


Please review [Hue Contributing Guide](https://github.com/cloudera/hue/blob/master/CONTRIBUTING.md) before opening a pull request.
