### PR TITLE
Add permissions for users per interpreter and upgrade sqlalchemy for clickhouse

### DIFF
--- a/desktop/conf.dist/hue.ini
+++ b/desktop/conf.dist/hue.ini
@@ -1045,6 +1045,8 @@ tls=no
 # [[[hive]]]
 #   name=Hive
 #   interface=hiveserver2
+#   Each key in permissions can be empty
+#   permissions='{"groups": ["admin", "viewer"], "users": ["admin", "readonly"]}'
 
 # [[[hplsql]]]
 #   name=Hplsql

--- a/desktop/libs/notebook/src/notebook/conf.py
+++ b/desktop/libs/notebook/src/notebook/conf.py
@@ -54,14 +54,30 @@ def _remove_duplications(a_list):
 
 def check_has_missing_permission(user, interpreter, user_apps=None):
   # TODO: port to cluster config
-  if user_apps is None:
-    user_apps = appmanager.get_apps_dict(user)  # Expensive method
-  return (interpreter == 'hive' and 'hive' not in user_apps) or \
-         (interpreter == 'impala' and 'impala' not in user_apps) or \
-         (interpreter == 'pig' and 'pig' not in user_apps) or \
-         (interpreter == 'solr' and 'search' not in user_apps) or \
-         (interpreter in ('spark', 'pyspark', 'r', 'jar', 'py', 'sparksql') and 'spark' not in user_apps) or \
-         (interpreter in ('java', 'spark2', 'mapreduce', 'shell', 'sqoop1', 'distcp') and 'oozie' not in user_apps)
+  permissions = INTERPRETERS.get()[interpreter].PERMISSIONS.get()
+
+  if permissions == {}:
+    return False
+
+  if len(permissions['users']) == 0 and len(permissions['groups']) == 0:
+    return False
+
+  if user.username in permissions['users']:
+    LOG.info(f'User {user.username} explicitly allowed to use {interpreter} by config')
+    return False    
+
+  matching_groups_qs = user.groups.filter(name__in=permissions['groups'])
+  LOG.info(f'User {user.username} matching {permissions["groups"]} {matching_groups_qs.exists()}')
+
+  return not matching_groups_qs.exists()
+  # if user_apps is None:
+  #   user_apps = appmanager.get_apps_dict(user)  # Expensive method
+  # return (interpreter == 'hive' and 'hive' not in user_apps) or \
+  #        (interpreter == 'impala' and 'impala' not in user_apps) or \
+  #        (interpreter == 'pig' and 'pig' not in user_apps) or \
+  #        (interpreter == 'solr' and 'search' not in user_apps) or \
+  #        (interpreter in ('spark', 'pyspark', 'r', 'jar', 'py', 'sparksql') and 'spark' not in user_apps) or \
+  #        (interpreter in ('java', 'spark2', 'mapreduce', 'shell', 'sqoop1', 'distcp') and 'oozie' not in user_apps)
 
 
 def _connector_to_interpreter(connector):
@@ -193,7 +209,13 @@ INTERPRETERS = UnspecifiedConfigSection(
         help=_t('Specific options for connecting to the server.'),
         type=coerce_json_dict,
         default='{}'
-      )
+      ),
+      PERMISSIONS=Config(
+        key='permissions',
+        help=_t('User groups that have permissions for the interpreter.'),
+        type=coerce_json_dict,
+        default='{}'
+      ),
     )
   )
 )

--- a/tools/docker/hue/Dockerfile
+++ b/tools/docker/hue/Dockerfile
@@ -81,7 +81,8 @@ RUN ./build/env/bin/pip install --no-cache-dir \
   # Needed for Jaeger \
   threadloop \
   # Fix Can't load plugin: sqlalchemy.dialects:clickhouse \
-  sqlalchemy-clickhouse \
+  # sqlalchemy-clickhouse \ The repo isn't maintained yet 
+  clickhouse-sqlalchemy==0.2.6 \
   # sqlalchemy-clickhouse depend on infi.clickhouse_orm \
   # install after sqlalchemy-clickhouse and version == 1.0.4 \
   # otherwise Code: 516, Authentication failed will display \


### PR DESCRIPTION


## What changes were proposed in this pull request?

- Add the ability to configure permissions for a user or user group per interpreter.
- If no permissions are configured, then the interpreter is open to all users.
- In the general Dockerfile, upgrade the ClickHouse SQLAlchemy library, because the old one appears to no longer be maintained.

## How was this patch tested?

- We built a Docker container and are running it in our production environment to query ClickHouse installations.
- The Docker image is available to anyone: ghcr.io/ozlevka-work/hue:v4.11.0-gethue.
